### PR TITLE
Reduce flickering when switching workspaces

### DIFF
--- a/src/Workspaces.hh
+++ b/src/Workspaces.hh
@@ -103,7 +103,8 @@ public:
 	static void remove(PWinObj* wo);
 
 	static void hideAll(uint workspace);
-	static void unhideAll(uint workspace, bool focus);
+	static void unhideAll(uint workspace);
+	static void setNewFocus(uint workspace);
 
 	static PWinObj* getLastFocused(uint workspace);
 	static void setLastFocused(uint workspace, PWinObj* wo);

--- a/src/Workspaces.hh
+++ b/src/Workspaces.hh
@@ -102,8 +102,7 @@ public:
 	static void insert(PWinObj* wo, bool raise = true);
 	static void remove(PWinObj* wo);
 
-	static void hideAll(uint workspace);
-	static void unhideAll(uint workspace);
+	static void hideAndUnhideAll(uint old_workspace, uint new_workspace);
 	static void setNewFocus(uint workspace);
 
 	static PWinObj* getLastFocused(uint workspace);


### PR DESCRIPTION
More details in the second commit's message. I have noticed this for a while (I have a habit of frequently switching back and forth between two workspaces). This seems to improve it a bit for me, but then it's probably because I wrote the changes and subconsciously convince myself it's better :)

I have no idea if this change of mapping/unmapping order has any bad consequences though. That's up to you to judge. And if you think this is not worth the risk (and not merge), I understand.