### PR TITLE
auto-release deb packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**
+!CMakeLists.txt
+!contrib
+!data
+!doc
+!src
+!test
+!CMake
+!nfpm.yaml.in

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,41 @@
+# it's used in a FROM so we need it early
+ARG BASE
+
+FROM goreleaser/nfpm:v2.18.1
+
+ARG BASE
+FROM $BASE
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+
+ARG JPEG
+RUN apt-get --no-install-recommends -y install cmake build-essential \
+    libx11-dev libfreetype6-dev $JPEG-dev curl ca-certificates fakeroot \
+    libxft2-dev
+
+WORKDIR /workspace/
+COPY ./ /workspace/
+
+ENV BUILD_TYPE=Release
+
+RUN set -e -x; \
+  cmake -E make_directory build; \
+  cd build; \
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DTESTS=ON ..; \
+  DESTDIR=target cmake --build . --target install --config $BUILD_TYPE
+
+ARG REF_NAME
+ARG BASE
+COPY --from=0 /usr/bin/nfpm /usr/local/bin
+RUN set -e -x; \
+  cd build; \
+  sed "s/libjpeg62-turbo/${JPEG}/" ../nfpm.yaml.in > nfpm.yaml ; \
+  export SEMVER="${REF_NAME#release-}~$(echo $BASE | sed 's/[^a-z0-9-]//g')"; \
+  nfpm pkg \
+    -f nfpm.yaml \
+    -p deb \
+    -t ../
+
+FROM scratch
+COPY --from=1 /workspace/*.deb .

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTESTS=ON -DDEV=ON
+      run: |
+        sudo apt-get -y install libxft2-dev
+        cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTESTS=ON -DDEV=ON
 
     - name: Build code style check tool
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    tags: ["release-*"]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: debian:11
+            jpeg: libjpeg62-turbo
+          - os: debian:sid
+            jpeg: libjpeg62-turbo
+          - os: ubuntu:18.04
+            jpeg: libjpeg62
+          - os: ubuntu:20.04
+            jpeg: libjpeg62
+          - os: ubuntu:22.04
+            jpeg: libjpeg62
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: build package
+      run: |
+        DOCKER_BUILDKIT=1 \
+        docker build \
+          --build-arg BASE=${{ matrix.os }} \
+          --build-arg JPEG=${{ matrix.jpeg }} \
+          --build-arg REF_NAME=${{ github.ref_name }} \
+          -f .github/workflows/Dockerfile \
+          --output type=local,dest=. \
+          .; \
+        echo "package=$(ls *.deb)" >> "$GITHUB_ENV"
+    - name: archive package
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.package }}
+        path: ${{ env.package }}
+        if-no-files-found: error
+
+  release:
+    needs:
+      - package
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Compute Version
+      run: |
+        SEMVER="${{ github.ref_name }}"
+        SEMVER="${SEMVER#release-}"
+        echo "semver=$SEMVER" >> "$GITHUB_ENV"
+
+    - name: Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+      with:
+        tag_name: ${{ env.semver }}
+        release_name: Release ${{ env.semver }}
+        draft: true
+        prerelease: false
+
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+
+  upload:
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name:
+          - debian11
+          - debiansid
+          - ubuntu1804
+          - ubuntu2004
+          - ubuntu2204
+
+    steps:
+    - name: Compute Version
+      run: |
+        SEMVER="${{ github.ref_name }}"
+        SEMVER="${SEMVER#release-}"
+        echo "semver=$SEMVER" >> "$GITHUB_ENV"
+
+    - name: get package from archive
+      uses: actions/download-artifact@v3
+      with:
+        name: pekwm_${{ env.semver }}~${{ matrix.name }}_amd64.deb
+
+    - name: Upload
+      id: upload-release-asset-linux64
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: pekwm_${{ env.semver }}~${{ matrix.name }}_amd64.deb
+        asset_name: pekwm_${{ env.semver }}~${{ matrix.name }}_amd64.deb
+        asset_content_type: application/octet-stream

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,10 @@ option(TESTS "include tests" OFF)
 option(DEV "include development tools" OFF)
 
 if (ENABLE_XFT)
-	find_package(Freetype)
+  find_package(Freetype)
+  if (NOT X11_Xft_FOUND)
+    message(FATAL_ERROR "Xft enabled but CMake says Xft not found")
+  endif()
 endif (ENABLE_XFT)
 
 if (ENABLE_IMAGE_JPEG)

--- a/nfpm.yaml.in
+++ b/nfpm.yaml.in
@@ -1,0 +1,47 @@
+name: pekwm
+arch: amd64
+platform: linux
+
+version: ${SEMVER}
+
+version_schema: semver
+
+section: x11
+priority: optional
+
+maintainer: Claes Nästén <pekdon@gmail.com>
+description: |
+  A light, unobtrusive, and configurable windowmanager.
+  .
+  Most notable features include grouping (a la Fluxbox, Ion, or PWM), automatic
+  properties, and a chainable keygrabber.
+
+homepage: https://www.pekwm.se/
+
+provides:
+  - x-window-manager
+
+depends:
+  - menu
+  - x11-utils
+  - libc6 (>= 2.15)
+  - libgcc-s1 (>= 3.0)
+  - libjpeg62-turbo
+  - libpng16-16 (>= 1.6.2-1)
+  - libstdc++6 (>= 5.2)
+  - libx11-6
+  - libxext6
+  - libxft2 (>> 2.1.1)
+  - libxinerama1
+  - libxpm4
+  - libxrandr2 (>= 2:1.2.0)
+  - libxft2
+
+contents:
+  - src: target/usr
+    dst: /usr
+  - src: target/etc
+    dst: /etc
+
+deb:
+  compression: xz

--- a/pkg.sh
+++ b/pkg.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# pkg.sh can be run to manually perform package builds using the same
+# mechanisms used for automated builds during release
+
+set -e
+
+build() {
+  DOCKER_BUILDKIT=1 \
+  docker build \
+    --build-arg BASE="$1" \
+    --build-arg JPEG="$2" \
+    --build-arg REF_NAME=$(git rev-parse --short HEAD) \
+    --output type=local,dest=. \
+    -f .github/workflows/Dockerfile \
+    .
+}
+
+build ubuntu:18.04 libjpeg62
+build ubuntu:20.04 libjpeg62
+build ubuntu:22.04 libjpeg62
+build debian:11    libjpeg62-turbo
+build debian:sid   libjpeg62-turbo


### PR DESCRIPTION
hi!

This change adds a new workflow that, when a tag matching `release-X.Y.Z` is pushed, automatically creates releases and uploads a `.deb` build to them. goreleaser/nfpm is used to build the DEB, so we add an `nfpm.yaml` to configure it, as well.

It's easy to have the release created as a `draft` if you prefer.