### PR TITLE
New PR on X11::createWmWindow

### DIFF
--- a/src/DockApp.cc
+++ b/src/DockApp.cc
@@ -83,7 +83,7 @@ DockApp::DockApp(Window win) :
 
 	// create parent window which is going to hold the border
 	_window = X11::createWmWindow(X11::getRoot(),
-				      _gm.x, _gm.y, _gm.width, _gm.height,
+				      _gm.x, _gm.y, _gm.width, _gm.height, InputOutput,
 				      SubstructureRedirectMask|ButtonPressMask|
 				      ButtonMotionMask);
 

--- a/src/InputDialog.cc
+++ b/src/InputDialog.cc
@@ -133,7 +133,7 @@ InputDialog::InputDialog(const std::string &title)
 	_text_wo = new PWinObj(true);
 
 	Window window =
-		X11::createWmWindow(_window, 0, 0, 1, 1,
+		X11::createWmWindow(_window, 0, 0, 1, 1, InputOutput,
 				    ButtonPressMask|ButtonReleaseMask|
 				    ButtonMotionMask|FocusChangeMask|
 				    KeyPressMask|KeyReleaseMask);

--- a/src/ManagerWindows.cc
+++ b/src/ManagerWindows.cc
@@ -42,7 +42,7 @@ HintWO::HintWO(Window root)
 	_type = WO_SCREEN_HINT;
 	setLayer(LAYER_NONE);
 
-	_window = X11::createWmWindow(X11::getRoot(), -200, -200, 5, 5,
+	_window = X11::createWmWindow(X11::getRoot(), -200, -200, 5, 5, InputOutput,
 				      PropertyChangeMask);
 
 	// Set hints not being updated
@@ -585,7 +585,7 @@ EdgeWO::EdgeWO(RootWO* root_wo, EdgeType edge, bool set_strut,
 	_iconified = true; // hack, to be ignored when placing
 	_focusable = false; // focusing input only windows crashes X
 
-	_window = X11::createWmWindow(root_wo->getWindow(), 0, 0, 1, 1,
+	_window = X11::createWmWindow(root_wo->getWindow(), 0, 0, 1, 1, InputOnly,
 				      EnterWindowMask|LeaveWindowMask|
 				      ButtonPressMask|ButtonReleaseMask);
 

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -51,7 +51,7 @@ PDecor::Button::Button(PWinObj *parent, Theme::PDecorButtonData *data,
 
 	_window = X11::createWmWindow(_parent->getWindow(),
 				      -_gm.width, -_gm.height,
-				      _gm.width, _gm.height,
+				      _gm.width, _gm.height, InputOutput,
 				      EnterWindowMask|LeaveWindowMask);
 	setState(_state);
 }
@@ -1732,7 +1732,7 @@ void
 PDecor::applyBorderShapeNormal(int kind, bool client_shape)
 {
 	Window shape = X11::createWmWindow(X11::getRoot(),
-					   0, 0, _gm.width, _gm.height, None);
+					   0, 0, _gm.width, _gm.height, InputOutput, None);
 	if (_child) {
 		X11::shapeCombine(shape, kind,
 				  bdLeft(this), bdTop(this) + titleHeight(this),
@@ -1771,11 +1771,11 @@ PDecor::applyBorderShapeShaded(int kind)
 		shape = X11::createWmWindow(X11::getRoot(),
 					    0, 0,
 					    _title_wo.getWidth(),
-					    _title_wo.getHeight(),
+					    _title_wo.getHeight(), InputOutput,
 					    None);
 	} else {
 		shape = X11::createWmWindow(X11::getRoot(),
-					    0, 0, _gm.width, _gm.height,
+					    0, 0, _gm.width, _gm.height, InputOutput,
 					    None);
 		if (_border) {
 			applyBorderShapeBorder(kind, shape);

--- a/src/PMenu.cc
+++ b/src/PMenu.cc
@@ -82,7 +82,7 @@ PMenu::PMenu(const std::string &title,
 		ButtonPressMask|ButtonReleaseMask|ButtonMotionMask|
 		ExposureMask|FocusChangeMask|KeyPressMask|KeyReleaseMask|
 		PointerMotionMask;
-	Window window = X11::createWmWindow(_window, 0, 0, 1, 1, event_mask);
+	Window window = X11::createWmWindow(_window, 0, 0, 1, 1, InputOutput, event_mask);
 	_menu_wo->setWindow(window);
 
 	titleAdd(&_title);

--- a/src/StatusWindow.cc
+++ b/src/StatusWindow.cc
@@ -31,7 +31,7 @@ StatusWindow::StatusWindow(Theme* theme)
 	setLayer(LAYER_NONE); // hack, goes over LAYER_MENU
 	_hidden = true; // don't care about it when changing worskpace etc
 
-	_status_wo->setWindow(X11::createWmWindow(_window, 0, 0, 1, 1, None));
+	_status_wo->setWindow(X11::createWmWindow(_window, 0, 0, 1, 1, CopyFromParent, None));
 	addChild(_status_wo);
 	activateChild(_status_wo);
 	_status_wo->mapWindow();

--- a/src/WorkspaceIndicator.cc
+++ b/src/WorkspaceIndicator.cc
@@ -30,7 +30,7 @@ WorkspaceIndicator::Display::Display(PWinObj *parent)
 
 	long event_mask = ButtonPressMask|ButtonReleaseMask|ButtonMotionMask|
 			  FocusChangeMask|KeyPressMask|KeyReleaseMask;
-	_window = X11::createWmWindow(_parent->getWindow(), 0, 0, 1, 1,
+	_window = X11::createWmWindow(_parent->getWindow(), 0, 0, 1, 1, InputOutput,
 				      event_mask);
 }
 

--- a/src/X11.cc
+++ b/src/X11.cc
@@ -1955,14 +1955,14 @@ X11::createSimpleWindow(Window parent,
  * set to true.
  */
 Window
-X11::createWmWindow(Window parent, int x, int y, uint width, uint height,
+X11::createWmWindow(Window parent, int x, int y, uint width, uint height, uint _class,
 		    ulong event_mask)
 {
 	XSetWindowAttributes attr;
 	attr.event_mask = event_mask;
 	attr.override_redirect = True;
 	return createWindow(parent, x, y, width, height, 0,
-			    CopyFromParent, InputOutput, CopyFromParent,
+			    CopyFromParent, _class, CopyFromParent,
 			    CWEventMask|CWOverrideRedirect, &attr);
 }
 

--- a/src/X11.cc
+++ b/src/X11.cc
@@ -1956,7 +1956,7 @@ X11::createSimpleWindow(Window parent,
  */
 Window
 X11::createWmWindow(Window parent, int x, int y, uint width, uint height,
-		    int event_mask)
+		    ulong event_mask)
 {
 	XSetWindowAttributes attr;
 	attr.event_mask = event_mask;

--- a/src/X11.hh
+++ b/src/X11.hh
@@ -446,7 +446,7 @@ public:
 					 uint border_width,
 					 ulong border, ulong background);
 	static Window createWmWindow(Window parent,
-				     int x, int y, uint width, uint height,
+				     int x, int y, uint width, uint height, uint _class,
 				     ulong event_mask);
 	static void destroyWindow(Window win);
 	static void changeWindowAttributes(Window win, ulong mask,

--- a/src/X11.hh
+++ b/src/X11.hh
@@ -447,7 +447,7 @@ public:
 					 ulong border, ulong background);
 	static Window createWmWindow(Window parent,
 				     int x, int y, uint width, uint height,
-				     int event_mask);
+				     ulong event_mask);
 	static void destroyWindow(Window win);
 	static void changeWindowAttributes(Window win, ulong mask,
 					   XSetWindowAttributes &attrs);


### PR DESCRIPTION
Same PR as before except Volume buttons related changes.
Modified files cover resolving of bug caused visual artifacts after X11::createWmWindow method introduced.
X11::createWmWindow method now has _class attribute and can vary Input/InputOutput.