### PR TITLE
Fix ButtonRelaseMask on Client

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -778,7 +778,7 @@ Client::grabButtons(void)
 		cfg->getMouseActionList(MOUSE_ACTION_LIST_CHILD_FRAME);
 	std::vector<ActionEvent>::iterator it = actions->begin();
 
-	const uint mask = ButtonPressMask;
+	const uint mask = ButtonPressMask|ButtonReleaseMask;
 	for (; it != actions->end(); ++it) {
 		if (it->isButtonEvent()) {
 			// not grabbing actions without modifier, will be


### PR DESCRIPTION
In commit https://github.com/pekwm/pekwm/commit/89e6c9515ca6e40336f89520a594068d108e816d the ButtonReleaseMask was removed for unknown reason, readd it.
Closes issue #163
