### PR TITLE
Fix harbour placement on the right edge

### DIFF
--- a/src/Harbour.cc
+++ b/src/Harbour.cc
@@ -396,7 +396,7 @@ Harbour::placeDockApp(DockApp *da)
 	if (x_place) {
 		placeDockAppX(da, head, x, y);
 	} else {
-		placeDockAppX(da, head, x, y);
+		placeDockAppY(da, head, x, y);
 	}
 
 	da->move(x, y);
@@ -436,6 +436,43 @@ Harbour::placeDockAppX(DockApp* da, const Geometry& head, int& x, const int y)
 			x = test;
 		} else if (increase) {
 			test += right ? -1 : 1;
+		}
+	}
+}
+
+void
+Harbour::placeDockAppY(DockApp *da, const Geometry& head, const int x, int &y)
+{
+	int test;
+	bool placed = false, increase = false;
+	bool bottom = (_cfg->getHarbourOrientation() == BOTTOM_TO_TOP);
+	y = test = bottom ? head.y + head.height - da->getHeight() : head.y;
+
+	while (! placed
+	       && (bottom
+		   ? (test >= 0)
+		   : ((test + da->getHeight()) < (head.y + head.height)))) {
+		placed = increase = true;
+
+		std::vector<DockApp*>::const_iterator it = _dapps.begin();
+		for (; placed && it != _dapps.end(); ++it) {
+			if ((*it) == da) {
+				continue; // exclude ourselves
+			}
+
+			int ty = static_cast<signed>(test + da->getHeight());
+			if (((*it)->getY() < ty) && ((*it)->getBY() > test)) {
+				placed = increase = false;
+				test = bottom
+					? (*it)->getY() - da->getHeight()
+					: (*it)->getBY();
+			}
+		}
+
+		if (placed) {
+			y = test;
+		} else if (increase) {
+			test += bottom ? -1 : 1;
 		}
 	}
 }

--- a/src/Harbour.hh
+++ b/src/Harbour.hh
@@ -57,6 +57,8 @@ private:
 	void placeDockApp(DockApp *da);
 	void placeDockAppX(DockApp *da, const Geometry& head,
 			   int& x, const int y);
+	void placeDockAppY(DockApp *da, const Geometry& head,
+			   const int x, int &y);
 	void placeDockAppsSorted(void);
 	void placeDockAppInsideScreen(DockApp *da);
 


### PR DESCRIPTION
Commit b780659 (Fix max line-length and too many space indents, 2022-07-16) factors out the code inside Harbour::placeDockApp() into placeDockAppX and placeDockAppY but never calls the latter. Later on placeDockAppY() is deleted in another cleanup commit.

I do not understand how I only noticed this now [1] but with default harbor setting (on the right edge), all the dock apps are now moved to the left edge. And this seems to fix this, but to be honest I don't really know what I'm doing.

[1] well not now, a few months but I was too lazy to go check