### PR TITLE
Raise newly focused window when current one closes

### DIFF
--- a/src/Workspaces.cc
+++ b/src/Workspaces.cc
@@ -974,6 +974,7 @@ Workspaces::findWOAndFocus(PWinObj *search)
 
 	if (focus) {
 		focus->giveInputFocus();
+		focus->raise();
 	}  else if (! PWinObj::getFocusedPWinObj()) {
 		pekwm::rootWo()->giveInputFocus();
 		pekwm::rootWo()->setEwmhActiveWindow(None);


### PR DESCRIPTION
The current behavior is confusing. All windows are maximized. Open Emacs, Alt-tab over all windows back to Emacs. Close Emacs. The chosen window to have focus (because Emacs window is gone) is _not_ the one on top [1].

So you don't really see what window is being focused (remember all windows are maximized). Whatever you type is going to a window you cannot see.

The behavior is different if you don't just cycle through all windows.

[1] because it's chosen from MRU list, but I'm not exactly sure how MRU list is updated, when alt-tabbing. So perhaps the problem is with    updating MRU correctly.