### PR TITLE
Skip all but normal menu items in GotoItem (close #175)

### DIFF
--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -1440,7 +1440,7 @@ PDecor::renderButtons(void)
 void
 PDecor::renderBorder(void)
 {
-	if (! _border) {
+	if (! _data || ! _border) {
 		return;
 	}
 
@@ -1460,6 +1460,9 @@ PDecor::renderBorder(void)
 void
 PDecor::setBorderShape(void)
 {
+	if (! _data) {
+		return;
+	}
 #ifdef PEKWM_HAVE_SHAPE
 	Pixmap pix;
 	bool do_free;
@@ -1905,7 +1908,7 @@ PDecor::restackBorder(void)
 
 	// Raise the top window so actual restacking is done.
 	X11::raiseWindow(windows[0]);
-	XRestackWindows(X11::getDpy(), windows, BORDER_NO_POS + extra);
+	X11::stackWindows(windows, BORDER_NO_POS + extra);
 }
 
 /**

--- a/src/PMenu.hh
+++ b/src/PMenu.hh
@@ -149,7 +149,7 @@ public:
 	void selectItem(std::vector<PMenu::Item*>::const_iterator item,
 			bool unmap_submenu = true);
 	void deselectItem(bool unmap_submenu = true);
-	void selectItemNum(uint num);
+	bool selectItemNum(uint num);
 	void selectItemRel(int off);
 	void exec(PMenu::Item *item);
 

--- a/src/ThemeGm.cc
+++ b/src/ThemeGm.cc
@@ -39,7 +39,7 @@ ThemeGm::titleWidth(const ThemeState *state, const std::string& str) const {
 /** Calculate title height, 0 if titlebar is disabled. */
 uint
 ThemeGm::titleHeight(const ThemeState *state) const {
-	if (! state->hasTitlebar()) {
+	if (! _data || ! state->hasTitlebar()) {
 		return 0;
 	}
 

--- a/src/lib/Iter.hh
+++ b/src/lib/Iter.hh
@@ -1,0 +1,56 @@
+//
+// Iter.hh for pekwm
+// Copyright (C) 2024 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#ifndef _PEKWM_ITER_HH_
+#define _PEKWM_ITER_HH_
+
+template<typename T, typename V>
+class FilterIt
+{
+public:
+	typedef bool(*filter_fun)(V v);
+
+	FilterIt(T begin, T end, filter_fun filter_fun)
+		: _it(begin),
+		  _end(end),
+		  _filter_fun(filter_fun)
+	{
+		skipFilter();
+	}
+
+	bool isValid() const { return _it != _end; }
+	bool next()
+	{
+		if (isValid()) {
+			++_it;
+			return skipFilter();
+		}
+		return false;
+	}
+	T operator*() const { return _it; }
+
+private:
+	bool skipFilter()
+	{
+		while (isValid() && !filter(_it)) {
+			++_it;
+		}
+		return isValid();
+	}
+
+	bool filter(T it)
+	{
+		return _filter_fun(*it);
+	}
+
+	T _it;
+	T _end;
+	filter_fun _filter_fun;
+};
+
+#endif // _PEKWM_ITER_HH_

--- a/src/lib/X11.cc
+++ b/src/lib/X11.cc
@@ -1725,7 +1725,9 @@ X11::shapeIntersectRect(Window dst, XRectangle *rect)
 void
 X11::shapeSetMask(Window dst, int kind, Pixmap pix)
 {
-	XShapeCombineMask(_dpy, dst, kind, 0, 0, pix, ShapeSet);
+	if (_dpy) {
+		XShapeCombineMask(_dpy, dst, kind, 0, 0, pix, ShapeSet);
+	}
 }
 #else // ! PEKWM_HAVE_SHAPE
 void
@@ -2178,7 +2180,7 @@ X11::ungrabButton(uint button, uint modifiers, Window win)
 void
 X11::stackWindows(Window *wins, unsigned len)
 {
-	if (len > 1) {
+	if (_dpy && len > 1) {
 		XRestackWindows(_dpy, wins, len);
 	}
 }

--- a/test/test.hh
+++ b/test/test.hh
@@ -47,7 +47,17 @@ AssertFailed::format(const std::string &suite_name,
 		__test_oss << " expected true";         \
 		__test_oss << " got " << (actual);      \
 		ASSERT_FAILED(__test_oss.str())         \
-			}
+	}
+
+#define ASSERT_FALSE(msg, actual)			\
+	if ((actual)) {					\
+		std::ostringstream __test_oss;          \
+		__test_oss << (msg);                    \
+		__test_oss << " expected false";        \
+		__test_oss << " got " << (actual);      \
+		ASSERT_FAILED(__test_oss.str())         \
+	}
+
 
 #define ASSERT_EQUAL(msg, expected, actual)			\
 	if ((expected) != (actual)) {				\

--- a/test/test_PMenu.hh
+++ b/test/test_PMenu.hh
@@ -1,0 +1,91 @@
+//
+// test_PMenu.cc for pekwm
+// Copyright (C) 2024 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "test.hh"
+#include "PMenu.hh"
+
+class TestPMenu : public TestSuite {
+public:
+	TestPMenu();
+	~TestPMenu();
+
+	bool run_test(TestSpec spec, bool status);
+
+private:
+	void testSelectItemNum();
+	void testSelectItemNumSkipFirst();
+	void testSelectItemNumSkipAll();
+};
+
+TestPMenu::TestPMenu()
+	: TestSuite("PMenu")
+{
+}
+
+TestPMenu::~TestPMenu()
+{
+}
+
+bool
+TestPMenu::run_test(TestSpec spec, bool status)
+{
+	TEST_FN(spec, "selectItemNum", testSelectItemNum());
+	TEST_FN(spec, "selectItemNumSkipFirt", testSelectItemNumSkipFirst());
+	TEST_FN(spec, "selectItemNumSkipAll", testSelectItemNumSkipAll());
+	return status;
+}
+
+void
+TestPMenu::testSelectItemNum()
+{
+	PMenu menu("title", "test", "decor", false);
+	ASSERT_FALSE("non existing item should fail", menu.selectItemNum(0));
+	ASSERT_FALSE("non existing item should fail", menu.selectItemNum(10));
+
+	menu.insert(new PMenu::Item("first"));
+	PMenu::Item *sep = new PMenu::Item("");
+	sep->setType(PMenu::Item::MENU_ITEM_SEPARATOR);
+	menu.insert(sep);
+	menu.insert(new PMenu::Item("third"));
+
+	ASSERT_TRUE("select first", menu.selectItemNum(0));
+	ASSERT_EQUAL("select first", "first",
+		     menu.getItemCurr()->getName());
+	ASSERT_TRUE("select second", menu.selectItemNum(1));
+	ASSERT_EQUAL("select second", "third",
+		     menu.getItemCurr()->getName());
+	ASSERT_FALSE("separator should be skipped", menu.selectItemNum(2));
+}
+
+void TestPMenu::testSelectItemNumSkipFirst()
+{
+	PMenu menu("title", "test", "decor", false);
+
+	PMenu::Item *sep = new PMenu::Item("");
+	sep->setType(PMenu::Item::MENU_ITEM_SEPARATOR);
+	menu.insert(sep);
+	menu.insert(new PMenu::Item("first"));
+
+	ASSERT_TRUE("select first", menu.selectItemNum(0));
+	ASSERT_EQUAL("select first", "first",
+		     menu.getItemCurr()->getName());
+}
+
+void TestPMenu::testSelectItemNumSkipAll()
+{
+	PMenu menu("title", "test", "decor", false);
+
+	PMenu::Item *sep;
+	sep = new PMenu::Item("");
+	sep->setType(PMenu::Item::MENU_ITEM_SEPARATOR);
+	menu.insert(sep);
+	sep = new PMenu::Item("");
+	sep->setType(PMenu::Item::MENU_ITEM_SEPARATOR);
+
+	ASSERT_FALSE("select none", menu.selectItemNum(0));
+}

--- a/test/test_pekwm.cc
+++ b/test/test_pekwm.cc
@@ -24,6 +24,7 @@
 #include "test_PFontPango.hh"
 #endif // PEKWM_HAVE_PANGO
 #include "test_PFontXmb.hh"
+#include "test_PMenu.hh"
 #include "test_Theme.hh"
 #include "test_WindowManager.hh"
 #include "test_X11.hh"
@@ -65,6 +66,9 @@ main_tests(int argc, char *argv[])
 	TestPFontPango testPFontPango;
 #endif // PEKWM_HAVE_PANGO
 	TestPFontXmb testPFontXmb;
+
+	// PMenu
+	TestPMenu testPMenu;
 
 	// Theme
 	TestTheme testTheme;


### PR DESCRIPTION
GotoItem now skips separators and other non displayed menu items.