### PR TITLE
Don't set override_redirect to True on non WM PDecors (Close #174)

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1,6 +1,6 @@
 //
 // Frame.cc for pekwm
-// Copyright (C) 2002-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2002-2024 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -50,7 +50,7 @@ bool Frame::_tag_behind = false;
 
 
 Frame::Frame()
-	: PDecor(DEFAULT_DECOR_NAME, None, false),
+	: PDecor(None, true, false),
 	  _id(0),
 	  _client(nullptr),
 	  _class_hint(nullptr),
@@ -60,7 +60,7 @@ Frame::Frame()
 }
 
 Frame::Frame(Client *client, AutoProperty *ap)
-	: PDecor(client->getAPDecorName(), client->getWindow(), true),
+	: PDecor(client->getWindow(), false, true, client->getAPDecorName()),
 	  _id(0),
 	  _client(client),
 	  _class_hint(nullptr),

--- a/src/InputDialog.cc
+++ b/src/InputDialog.cc
@@ -1,6 +1,6 @@
 //
 // InputDialog.cc for pekwm
-// Copyright (C) 2009-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2009-2024 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -109,7 +109,7 @@ InputBuffer::changePos(int off)
  * InputDialog constructor.
  */
 InputDialog::InputDialog(const std::string &title)
-	: PDecor("INPUTDIALOG"), PWinObjReference(0),
+	: PDecor(None, true, true, "INPUTDIALOG"), PWinObjReference(0),
 	  _data(pekwm::theme()->getCmdDialogData()),
 	  _buf_off(0),
 	  _buf_chars(0)

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -190,8 +190,8 @@ std::vector<PDecor*> PDecor::_pdecors;
 //! @brief PDecor constructor
 //! @param dpy Display
 //! @param decor_name String, if not DEFAULT_DECOR_NAME sets _decor_name_saved
-PDecor::PDecor(const std::string &decor_name, const Window child_window,
-	       bool init)
+PDecor::PDecor(const Window child_window, bool override_redirect, bool init,
+	       const std::string &decor_name)
 	: PWinObj(true),
 	  ThemeGm(nullptr),
 	  _decor_name(decor_name),
@@ -219,13 +219,13 @@ PDecor::PDecor(const std::string &decor_name, const Window child_window,
 	  _titles_right(1)
 {
 	if (init) {
-		this->init(child_window);
+		this->init(child_window, override_redirect);
 	}
 	_pdecors.push_back(this);
 }
 
 void
-PDecor::init(Window child_window)
+PDecor::init(Window child_window, bool override_redirect)
 {
 	if (_decor_name.empty()) {
 		_decor_name = getDecorName();
@@ -236,7 +236,7 @@ PDecor::init(Window child_window)
 
 	setDataFromDecorName(_decor_name);
 
-	CreateWindowParams window_params;
+	CreateWindowParams window_params(override_redirect);
 	createParentWindow(window_params, child_window);
 	createTitle(window_params);
 	createBorder(window_params);
@@ -257,7 +257,6 @@ PDecor::createParentWindow(CreateWindowParams &params, Window child_window)
 	params.mask = CWOverrideRedirect|CWEventMask|CWBorderPixel|CWBackPixel;
 	params.depth = CopyFromParent;
 	params.visual = CopyFromParent;
-	params.attr.override_redirect = True;
 	params.attr.border_pixel = X11::getBlackPixel();
 	params.attr.background_pixel = X11::getBlackPixel();
 

--- a/src/PDecor.hh
+++ b/src/PDecor.hh
@@ -1,6 +1,6 @@
 //
 // PDecor.hh for pekwm
-// Copyright (C) 2004-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2004-2024 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -23,6 +23,12 @@ class PFont;
  */
 class CreateWindowParams {
 public:
+	CreateWindowParams(bool override_redirect)
+	{
+		attr.override_redirect = override_redirect;
+	}
+
+	bool override_redirect;
 	int depth;
 	long mask;
 	XSetWindowAttributes attr;
@@ -123,9 +129,8 @@ public:
 		uint _width;
 	};
 
-	PDecor(const std::string &decor_name = DEFAULT_DECOR_NAME,
-	       const Window child_window = None,
-	       bool init = true);
+	PDecor(const Window child_window, bool override_redirect, bool init,
+	       const std::string &decor_name = DEFAULT_DECOR_NAME);
 	virtual ~PDecor(void);
 
 	// START - PWinObj interface.
@@ -322,7 +327,7 @@ protected:
 	}
 
 private:
-	void init(Window child_window);
+	void init(Window child_window, bool override_redirect);
 
 	void createParentWindow(CreateWindowParams &params,
 				Window child_window);

--- a/src/PMenu.cc
+++ b/src/PMenu.cc
@@ -54,7 +54,7 @@ std::map<Window,PMenu*> PMenu::_menu_map = std::map<Window,PMenu*>();
 PMenu::PMenu(const std::string &title,
 	     const std::string &name, const std::string& decor_name,
 	     bool init)
-	: PDecor(decor_name, None, init),
+	: PDecor(None, true, init, decor_name),
 	  _name(name),
 	  _menu_parent(0), _class_hint("pekwm", "Menu", "", "", ""),
 	  _item_curr(0),

--- a/src/StatusWindow.cc
+++ b/src/StatusWindow.cc
@@ -1,6 +1,6 @@
 //
 // StatusWindow.cc for pekwm
-// Copyright (C) 2017-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2017-2024 Claes Nästén <pekdon@gmail.com>
 // Copyright (C) 2004-2016 the pekwm development team
 //
 // This program is licensed under the GNU GPL.
@@ -23,7 +23,7 @@
 
 //! @brief StatusWindow constructor
 StatusWindow::StatusWindow(Theme* theme)
-	: PDecor("STATUSWINDOW"),
+	: PDecor(None, true, true, "STATUSWINDOW"),
 	  _theme(theme),
 	  _status_wo(new PWinObj(false))
 {

--- a/src/WORefMenu.cc
+++ b/src/WORefMenu.cc
@@ -1,6 +1,6 @@
 //
-// WORefMenu.hh for pekwm
-// Copyright (C) 2004-2023 Claes Nästen <pekdon@gmail.com>
+// WORefMenu.cc for pekwm
+// Copyright (C) 2004-2024 Claes Nästen <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.

--- a/src/WorkspaceIndicator.cc
+++ b/src/WorkspaceIndicator.cc
@@ -1,6 +1,6 @@
 //
 // WorkspaceIndicator.cc for pekwm
-// Copyright (C) 2021-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2021-2024 Claes Nästén <pekdon@gmail.com>
 // Copyright (C) 2009-2020 the pekwm development team
 //
 // This program is licensed under the GNU GPL.
@@ -169,7 +169,7 @@ WorkspaceIndicator::Display::getPaddingVertical(void)
  * WorkspaceIndicator constructor
  */
 WorkspaceIndicator::WorkspaceIndicator()
-	: PDecor("WORKSPACEINDICATOR"),
+	: PDecor(None, true, true, "WORKSPACEINDICATOR"),
 	  _display_wo(this)
 {
 	_type = PWinObj::WO_WORKSPACE_INDICATOR;


### PR DESCRIPTION
Seemingly other window managers do not set override_redirect on decor windows X11 clients get reparented to. To improve client compatability, and detection of what is a client window and a WM window, set this on PDecor for Frame but no other window manager windows.