### PR TITLE
Add auto property for overriding placement model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ New
   the MRU list to find a client when the focused object is closed.
   `OnCloseFocusRaise`, controls wheter the window focused is raised. IfCovered
   will raise the window if it is mostly covered by other windows.
+* Add auto property `Placement` for overriding the placement model for specific
+  clients.
 
 Updated
 -------

--- a/doc/autoproperties.md
+++ b/doc/autoproperties.md
@@ -383,6 +383,12 @@ take effect.
 
 Toggles the use of placing rules for this client.
 
+**Placement (string)**
+
+Sets the placement model for the given client overriding the default placement
+model set in the configuration. String is a space separated list of placement
+models to try.
+
 **Role (string)**
 
 Apply this autoproperty on clients that have a WM\_WINDOW\_ROLE hint

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -220,7 +220,6 @@ Screen {
 
 	Placement {
 		Model = "Smart"
-		WorkspacePlacements = "Smart;MouseCentered"
 		Smart {
 			Row = "False"
 			TopToBottom = "True"
@@ -339,8 +338,6 @@ all values should be placed inside quotes.
 | Keyword             | Type    | Description                                                                                                                       |
 |---------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Model               | string  | Default placement model, one of the below Placement Models.                                                                       |
-| WorkspacePlacements | string  | List of placement models for the workspaces separated by semicolon. For an explanation of the allowed options see "Model" above.  |
-
 Placement Models:
 
 * _Smart_, Tries to place windows where no other window is present

--- a/src/AutoProperties.hh
+++ b/src/AutoProperties.hh
@@ -1,6 +1,6 @@
 //
 // AutoProperties.hh for pekwm
-// Copyright (C) 2003-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2003-2025 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -11,7 +11,6 @@
 
 #include "config.h"
 
-#include "pekwm.hh"
 #include "CfgParser.hh"
 #include "tk/ImageHandler.hh"
 #include "tk/PImageIcon.hh"
@@ -47,6 +46,7 @@ enum PropertyType {
 	AP_OPACITY = (1L << 20),
 	AP_DECOR = (1L << 21),
 	AP_ICON = (1L << 22),
+	AP_PLACEMENT = (1L << 23),
 
 	AP_GROUP_SIZE,
 	AP_GROUP_BEHIND,
@@ -159,6 +159,7 @@ public:
 
 	std::string frame_decor;
 	PImageIcon *icon;
+	int win_layouter_types;
 
 	// grouping variables
 	int group_size;
@@ -234,6 +235,9 @@ public:
 	void removeApplyOnStart(void);
 
 	static bool matchAutoClass(const ClassHint &hint, Property *prop);
+
+protected:
+	int parsePlacement(const std::string &value);
 
 private:
 	Property* findProperty(const ClassHint* class_hint,

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1,6 +1,6 @@
 //
 // Frame.cc for pekwm
-// Copyright (C) 2002-2024 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2002-2025 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -10,8 +10,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <functional>
-#include <iostream>
 
 extern "C" {
 #include <X11/Xatom.h>
@@ -21,7 +19,6 @@ extern "C" {
 #include "PDecor.hh"
 #include "Frame.hh"
 
-#include "Charset.hh"
 #include "Compat.hh"
 #include "X11.hh"
 #include "Config.hh"
@@ -30,12 +27,9 @@ extern "C" {
 #include "Client.hh"
 #include "ClientMgr.hh"
 #include "ManagerWindows.hh"
-#include "StatusWindow.hh"
 #include "Workspaces.hh"
-#include "KeyGrabber.hh"
 
 #include "tk/PWinObj.hh"
-#include "tk/Theme.hh"
 #include "tk/X11Util.hh"
 
 std::vector<Frame*> Frame::_frames;
@@ -142,7 +136,8 @@ Frame::Frame(Client *client, AutoProperty *ap)
 
 	// still need a position?
 	if (place) {
-		Workspaces::layout(this, client->getTransientForClientWindow());
+		Workspaces::layout(this, client->getTransientForClientWindow(),
+				   ap ? ap->win_layouter_types : 0);
 	}
 
 	_old_gm = _gm;

--- a/src/Globals.cc
+++ b/src/Globals.cc
@@ -175,6 +175,12 @@ namespace pekwm
 		return _root_wo;
 	}
 
+	void setRootWO(RootWO* root_wo)
+	{
+		delete _root_wo;
+		_root_wo = root_wo;
+	}
+
 	ImageHandler* imageHandler(void)
 	{
 		return _image_handler;

--- a/src/ManagerWindows.cc
+++ b/src/ManagerWindows.cc
@@ -10,6 +10,7 @@
 
 #include "Config.hh"
 #include "Debug.hh"
+#include "Exception.hh"
 #include "ActionHandler.hh"
 #include "ManagerWindows.hh"
 #include "Workspaces.hh"

--- a/src/WinLayouter.hh
+++ b/src/WinLayouter.hh
@@ -1,6 +1,6 @@
 //
 // WinLayouter.hh for pekwm
-// Copyright (C) 2022 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2022-2025 Claes Nästén <pekdon@gmail.com>
 // Copyright © 2012-2013 Andreas Schlick <ioerror{@}lavabit{.}com>
 //
 // This program is licensed under the GNU GPL.
@@ -10,21 +10,44 @@
 #ifndef _PEKWM_WINLAYOUTER_HH_
 #define _PEKWM_WINLAYOUTER_HH_
 
-#include "Frame.hh"
-#include "X11.hh"
+#include "tk/PWinObj.hh"
 
 #include <string>
-#include <vector>
+
+enum WinLayouterType {
+	WIN_LAYOUTER_SMART = (1 << 0),
+	WIN_LAYOUTER_CENTERED = (1 << 1),
+	WIN_LAYOUTER_CENTEREDONPARENT = (1 << 2),
+	WIN_LAYOUTER_MOUSENOTUNDER = (1 << 3),
+	WIN_LAYOUTER_MOUSECENTERED = (1 << 4),
+	WIN_LAYOUTER_MOUSECTOPLEFT = (1 << 5),
+	WIN_LAYOUTER_NO = (1 << 6)
+};
+
+#define WIN_LAYOUTER_MASK 0x3f
+#define WIN_LAYOUTER_SHIFT 6
+#define WIN_LAYOUTER_MASK_NUM 5
 
 class WinLayouter {
 public:
-	WinLayouter(void) { }
-	virtual ~WinLayouter(void) { }
+	WinLayouter(enum WinLayouterType type)
+		: _type(type)
+	{
+	}
+	virtual ~WinLayouter() { }
+
+	enum WinLayouterType getType() const { return _type; }
 
 	virtual bool layout(PWinObj *wo, Window parent, const Geometry &gm,
 			    int ptr_x, int ptr_y)=0;
+
+private:
+	enum WinLayouterType _type;
 };
 
-WinLayouter *WinLayouterFactory(std::string name);
+enum WinLayouterType win_layouter_type_from_string(const std::string &name);
+
+WinLayouter *mkWinLayouter(const std::string &name);
+WinLayouter *mkWinLayouter(enum WinLayouterType type);
 
 #endif // _PEKWM_WINLAYOUTER_HH_

--- a/src/WindowManager.cc
+++ b/src/WindowManager.cc
@@ -125,6 +125,7 @@ WindowManager::start(const std::string &config_file,
 	// Setup window manager
 	Os *os = mkOs();
 	WindowManager *wm = new WindowManager(os);
+	Workspaces::init();
 	if (! pekwm::init(wm, wm, os, dpy, config_file, replace,
 			  synchronous)) {
 		delete wm;
@@ -282,7 +283,6 @@ WindowManager::setupDisplay(Display* dpy)
 {
 	pekwm::autoProperties()->load();
 
-	Workspaces::init();
 	Workspaces::setSize(pekwm::config()->getWorkspaces());
 	Workspaces::setPerRow(pekwm::config()->getWorkspacesPerRow());
 

--- a/src/Workspaces.hh
+++ b/src/Workspaces.hh
@@ -46,8 +46,10 @@ public:
 	typedef std::vector<PWinObj*>::const_reverse_iterator
 	const_reverse_iterator;
 
-	static void init(void);
-	static void cleanup(void);
+	typedef std::map<enum WinLayouterType, WinLayouter*> win_layouter_map;
+
+	static void init();
+	static void cleanup();
 
 	static inline iterator begin(void) { return _wobjs.begin(); }
 	static inline iterator end(void) { return _wobjs.end(); }
@@ -90,7 +92,8 @@ public:
 		return _workspaces[_active];
 	}
 
-	static void layout(Frame *frame, Window parent=None);
+	static void layout(Frame *frame, Window parent=None,
+			   int win_layouter_types=0);
 	static void insert(PWinObj* wo, bool raise = true);
 	static void remove(const PWinObj* wo);
 
@@ -161,12 +164,27 @@ protected:
 
 	static iterator find(const PWinObj *wo);
 
+	static bool layoutOnHead(PWinObj *wo, int win_layouter_types,
+				 Window parent, const Geometry &gm,
+				 int ptr_x, int ptr_y);
+	static bool layoutOnHeadTypes(PWinObj *wo, int win_layouter_types,
+				      Window parent, const Geometry &gm,
+				      int ptr_x, int ptr_y);
+
 	/** All PWinObjs, the highest stacked PWinObj is kept at the back. */
 	static std::vector<PWinObj*> _wobjs;
 	/** The most recently used frame is kept at the front. */
 	static std::vector<Frame*> _mru;
 
 private:
+	static WorkspaceIndicator *getWorkspaceIndicator()
+	{
+		if (_workspace_indicator == nullptr) {
+			_workspace_indicator = new WorkspaceIndicator();
+		}
+		return _workspace_indicator;
+	}
+
 	static PWinObj *findWOAndFocusStacking();
 	static PWinObj *findWOAndFocusMRU();
 	static void findWOAndFocusRaise(PWinObj *wo);
@@ -178,8 +196,6 @@ private:
 	static void stackAt(iterator it);
 
 	static void clearLayoutModels(void);
-	static bool layoutOnHead(PWinObj *wo, Window parent,
-				 const Geometry &gm, int ptr_x, int ptr_y);
 
 	static Window *buildClientList(unsigned int &num_windows);
 	static bool warpToWorkspace(uint num, int dir);
@@ -198,6 +214,7 @@ private:
 	static WorkspaceIndicator *_workspace_indicator;
 
 	static std::vector<Workspace> _workspaces;
+	static win_layouter_map _win_layouters;
 };
 
 #endif // _PEKWM_WORKSPACES_HH_

--- a/src/pekwm.hh
+++ b/src/pekwm.hh
@@ -15,11 +15,10 @@
 
 #include "AppCtrl.hh"
 #include "EventLoop.hh"
-#include "Types.hh"
-#include "Exception.hh"
 #include "Os.hh"
 
 class Config;
+class RootWO;
 
 namespace pekwm
 {
@@ -35,6 +34,7 @@ namespace pekwm
 	void setStarted(void);
 
 	void setConfig(Config* cfg);
+	void setRootWO(RootWO* root_wo);
 }
 
 #endif // _PEKWM_PEKWM_HH_

--- a/src/pekwm_wm.cc
+++ b/src/pekwm_wm.cc
@@ -11,6 +11,7 @@
 #include "Charset.hh"
 #include "Compat.hh"
 #include "Debug.hh"
+#include "Exception.hh"
 #include "WindowManager.hh"
 #include "Util.hh"
 #include "pekwm_env.hh"

--- a/test/test_AutoProperties.hh
+++ b/test/test_AutoProperties.hh
@@ -1,0 +1,63 @@
+//
+// test_AutoProperties.hh for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "test.hh"
+#include "AutoProperties.hh"
+#include "WinLayouter.hh"
+
+class AutoPropertiesTest : public AutoProperties {
+public:
+	AutoPropertiesTest() : AutoProperties(nullptr) { }
+	virtual ~AutoPropertiesTest() { }
+
+	int doParsePlacement(const std::string &str)
+	{
+		return AutoProperties::parsePlacement(str);
+	}
+};
+
+class TestAutoProperties : public TestSuite {
+public:
+	TestAutoProperties();
+	virtual ~TestAutoProperties();
+
+	virtual bool run_test(TestSpec spec, bool status);
+
+private:
+	static void testParsePlacement();
+};
+
+TestAutoProperties::TestAutoProperties()
+	: TestSuite("AutoProperties")
+{
+}
+
+TestAutoProperties::~TestAutoProperties()
+{
+}
+
+bool
+TestAutoProperties::run_test(TestSpec spec, bool status)
+{
+	TEST_FN(spec, "parsePlacement", testParsePlacement());
+	return status;
+}
+
+void
+TestAutoProperties::testParsePlacement()
+{
+	AutoPropertiesTest apt;
+	ASSERT_EQUAL("empty", 0, apt.doParsePlacement(""));
+	ASSERT_EQUAL("single", WIN_LAYOUTER_SMART,
+		     apt.doParsePlacement("SMART"));
+
+	int expected = WIN_LAYOUTER_CENTERED
+		| (WIN_LAYOUTER_MOUSECTOPLEFT << WIN_LAYOUTER_SHIFT);
+	ASSERT_EQUAL("multi", expected,
+		     apt.doParsePlacement("Centered MouseTopLeft"));
+}

--- a/test/test_Workspaces.hh
+++ b/test/test_Workspaces.hh
@@ -7,9 +7,8 @@
 //
 
 #include "test.hh"
+#include "ManagerWindows.hh"
 #include "Workspaces.hh"
-
-#include <utility>
 
 extern "C" {
 #include <X11/Xlib.h>
@@ -26,6 +25,7 @@ public:
 	void testSwapInStack();
 	void testStackAbove();
 	void testFindWOAndFocusFind();
+	void testLayoutOnHeadTypes();
 };
 
 TestWorkspaces::TestWorkspaces()
@@ -44,6 +44,7 @@ TestWorkspaces::run_test(TestSpec spec, bool status)
 	TEST_FN(spec, "swapInStack", testSwapInStack());
 	TEST_FN(spec, "stackAbove", testStackAbove());
 	TEST_FN(spec, "findWOAndFocusFind", testFindWOAndFocusFind());
+	TEST_FN(spec, "layoutOnHeadTypes", testLayoutOnHeadTypes());
 	return status;
 }
 
@@ -144,4 +145,29 @@ TestWorkspaces::testFindWOAndFocusFind()
 
 	_wobjs.clear();
 	_mru.clear();
+}
+
+void
+TestWorkspaces::testLayoutOnHeadTypes()
+{
+	Workspaces::init();
+	HintWO hint_wo(None);
+	Config cfg;
+	pekwm::setRootWO(new RootWO(None, &hint_wo, &cfg));
+
+	// not using MouseTopCenter will result in being placed at 0x0
+	std::vector<std::string> models;
+	models.push_back("SMART");
+
+	int win_layouter_types = WIN_LAYOUTER_MOUSECTOPLEFT;
+	PWinObj wo;
+	Geometry gm;
+	ASSERT_EQUAL("layout", true,
+		     layoutOnHeadTypes(&wo, win_layouter_types, None, gm,
+				       100, 200));
+	ASSERT_EQUAL("layout", 100, wo.getX());
+	ASSERT_EQUAL("layout", 200, wo.getY());
+
+	pekwm::setRootWO(nullptr);
+	Workspaces::cleanup();
 }

--- a/test/test_pekwm.cc
+++ b/test/test_pekwm.cc
@@ -1,6 +1,6 @@
 //
 // test_pekwm.cc for pekwm
-// Copyright (C) 2021-2024 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2021-2025 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -13,6 +13,7 @@
 #include "Debug.hh"
 
 #include "test_Action.hh"
+#include "test_AutoProperties.hh"
 #include "test_Config.hh"
 #include "test_FontHandler.hh"
 #include "test_Frame.hh"
@@ -39,6 +40,7 @@ main_tests(int argc, char *argv[])
 	Debug::setLogFile("/dev/null");
 	X11::addHead(Head(0, 0, 800, 600));
 
+	TestAutoProperties testAutoProperties;
 	// Action
 	TestAction testAction;
 	TestActionConfig testActionConfig;


### PR DESCRIPTION
New auto property for overriding the placement for specific clients.

Example for X calculator placing it under the cursor:

Property = "^xcalc,^XCalc" {
    ApplyOn = "New"
    Placement = "MouseCentered"
}