### PR TITLE
ColorPalette, access to pre-defined color combinations in themes.

### DIFF
--- a/src/Globals.cc
+++ b/src/Globals.cc
@@ -77,7 +77,9 @@ namespace pekwm
 		_hint_wo = new HintWO(X11::getRoot());
 		if (! _hint_wo->claimDisplay(replace)) {
 			delete _config;
+			_config = nullptr;
 			delete _hint_wo;
+			_hint_wo = nullptr;
 			X11::destruct();
 			return false;
 		}
@@ -128,8 +130,6 @@ namespace pekwm
 		delete _hint_wo;
 
 		X11::destruct();
-
-		delete _config;
 
 		cleanupNoDisplay();
 	}

--- a/src/panel/PanelTheme.cc
+++ b/src/panel/PanelTheme.cc
@@ -1,6 +1,6 @@
 //
 // PanelTheme.cc for pekwm
-// Copyright (C) 2022-2023 Claes Nästén <pekdon@gmail.com>
+// Copyright (C) 2022-2025 Claes Nästén <pekdon@gmail.com>
 //
 // This program is licensed under the GNU GPL.
 // See the LICENSE file for more information.
@@ -12,6 +12,7 @@
 #include "../tk/FontHandler.hh"
 #include "../tk/ImageHandler.hh"
 #include "../tk/TextureHandler.hh"
+#include "../tk/ThemeUtil.hh"
 
 #define DEFAULT_BACKGROUND "SolidRaised #ffffff #eeeeee #cccccc"
 #define DEFAULT_HEIGHT 24
@@ -49,9 +50,8 @@ PanelTheme::load(const std::string &theme_dir, const std::string& theme_path)
 {
 	unload();
 
-	CfgParser theme(CfgParserOpt("")); // FIXME: pekwm::configScriptPath());
-	theme.setVar("THEME_DIR", theme_dir);
-	if (! theme.parse(theme_path, CfgParserSource::SOURCE_FILE, true)) {
+	CfgParser theme(CfgParserOpt(""));
+	if (! ThemeUtil::load(theme, theme_dir, theme_path, true)) {
 		check();
 		return;
 	}
@@ -65,7 +65,7 @@ PanelTheme::load(const std::string &theme_dir, const std::string& theme_path)
 	uint opacity;
 	CfgParserKeys keys;
 	keys.add_string("BACKGROUND", background, DEFAULT_BACKGROUND);
-	keys.add_numeric<uint>("BACKGROUNDOPACITY", opacity, 100);
+	keys.add_numeric<uint>("BACKGROUNDOPACITY", opacity, 100, 0, 100);
 	keys.add_numeric<uint>("HEIGHT", _height, DEFAULT_HEIGHT);
 	keys.add_string("SEPARATOR", separator, DEFAULT_SEPARATOR);
 	keys.add_string("HANDLE", handle, "");
@@ -80,7 +80,13 @@ PanelTheme::load(const std::string &theme_dir, const std::string& theme_path)
 
 	TextureHandler *th = pekwm::textureHandler();
 	_background = th->getTexture(background);
-	_background_opacity = static_cast<uchar>(255.0 * opacity / 100.0);
+	if (opacity == 100) {
+		_background_opacity = 255;
+	} else {
+		_background_opacity =
+			static_cast<uchar>(255.0 * static_cast<float>(opacity)
+					   / 100.0);
+	}
 	_sep = th->getTexture(separator);
 	if (! handle.empty()) {
 		_handle = th->getTexture(handle);

--- a/src/panel/pekwm_panel.cc
+++ b/src/panel/pekwm_panel.cc
@@ -29,6 +29,7 @@
 #include "../tk/FontHandler.hh"
 #include "../tk/ImageHandler.hh"
 #include "../tk/TextureHandler.hh"
+#include "../tk/ThemeUtil.hh"
 #include "../tk/X11App.hh"
 #include "../tk/X11Util.hh"
 
@@ -94,6 +95,7 @@ loadTheme(PanelTheme& theme, CfgParser& cfg)
 
 	pekwm::fontHandler()->setDefaultFontX11(font_default_x11);
 	pekwm::fontHandler()->setCharsetOverride(font_charset_override);
+	ThemeUtil::loadRequire(cfg, theme_dir, theme_path);
 	theme.load(theme_dir, theme_path);
 
 	std::string icon_path;

--- a/src/tk/CMakeLists.txt
+++ b/src/tk/CMakeLists.txt
@@ -4,6 +4,7 @@ set(tk_SOURCES
     Action.cc
     CfgUtil.cc
     Color.cc
+    ColorPalette.cc
     FontHandler.cc
     ImageHandler.cc
     PFont.cc
@@ -18,6 +19,7 @@ set(tk_SOURCES
     Render.cc
     TextureHandler.cc
     Theme.cc
+    ThemeUtil.cc
     TkButton.cc
     TkButtonRow.cc
     TkText.cc

--- a/src/tk/Color.cc
+++ b/src/tk/Color.cc
@@ -8,8 +8,6 @@
 
 #include "Color.hh"
 #include "Debug.hh"
-#include "String.hh"
-#include "Util.hh"
 #include "X11.hh"
 
 #include <set>

--- a/src/tk/Color.hh
+++ b/src/tk/Color.hh
@@ -12,9 +12,7 @@
 #include "config.h"
 
 #include "Compat.hh"
-#include "Types.hh"
 
-#include <map>
 #include <string>
 
 #include "X11.hh"

--- a/src/tk/ColorPalette.cc
+++ b/src/tk/ColorPalette.cc
@@ -1,0 +1,138 @@
+//
+// ColorPalette.cc for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "Compat.hh"
+#include "ColorPalette.hh"
+#include "Util.hh"
+
+extern "C" {
+#include <assert.h>
+}
+
+namespace ColorPalette {
+
+static const int COLORS_PER_BASE = 5;
+
+const char *COLORS[] = {
+	"#fbd3d0", "#f57a6d", "#ef1c26", "#b81117", "#8f0307", // Red
+	"#e0cde3", "#be7cb4", "#a2218e", "#820e6e", "#68005c", // RedPurple
+	"#b8add5", "#7e6aae", "#592f94", "#491d75", "#37075c", // Purple
+	"#8b92c7", "#5764af", "#21409a", "#162e7c", "#081c63", // BluePurple
+	"#aec4e4", "#5c89c5", "#0465b1", "#004e8c", "#013c73", // Blue
+	"#bce4e7", "#56c3c5", "#00adae", "#018a89", "#006d6f", // BlueGreen
+	"#bfdfd0", "#64c297", "#03a55e", "#00864b", "#006c3c", // Green
+	"#e2ecd6", "#add68b", "#71bd44", "#569835", "#40782a", // YellowGreen
+	"#fefac9", "#fcf583", "#fef102", "#cbbe01", "#a29600", // Yellow
+	"#ffe3cb", "#fcc777", "#f8a61b", "#c28211", "#9b6702", // YellowOrange
+	"#fbdcc9", "#f4a973", "#f58225", "#c26819", "#9a4f06", // Orange
+	"#fccfc1", "#f48d74", "#ed403d", "#bb312d", "#972d1c"  // RedOrange
+};
+static const int COLORS_SIZE = sizeof(COLORS)/sizeof(COLORS[0]);
+
+static Util::StringTo<Mode> mode_map[] =
+	{{"SINGLE", PALETTE_SINGLE},
+	 {"COMPLEMENTARY", PALETTE_COMPLEMENTARY},
+	 {"TRIAD", PALETTE_TRIAD},
+	 {"ANALOGOUS", PALETTE_ANALOGOUS},
+	 {"SPLIT", PALETTE_SPLIT},
+	 {"TETRAD", PALETTE_TETRAD},
+	 {"SQUARE", PALETTE_SQUARE},
+	 {nullptr, PALETTE_NO}};
+
+static int *mode_steps[] =
+	{(int[]){0}, // PALETTE_SINGLE
+	 (int[]){6, 0}, // PALETTE_COMPLEMENTARY
+	 (int[]){4, 4, 0}, // PALETTE_TRIAD
+	 (int[]){1, 1, 0}, // PALETTE_ANALOGOUS
+	 (int[]){5, 2, 0}, // PALETTE_SPLIT
+	 (int[]){4, 2, 4, 0}, // PALETTE_TETRAD
+	 (int[]){3, 3, 3, 0}, // PALETTE_SQUARE
+	 (int[]){0}}; // PALETTE_NO
+
+static Util::StringTo<BaseColor> base_color_map[] = 
+	{{"RED", BASE_COLOR_RED},
+	 {"REDPURPLE", BASE_COLOR_RED_PURPLE},
+	 {"PURPLE", BASE_COLOR_PURPLE},
+	 {"BLUEPURPLE", BASE_COLOR_BLUE_PURPLE},
+	 {"BLUE", BASE_COLOR_BLUE},
+	 {"BLUEGREEN", BASE_COLOR_BLUE_GREEN},
+	 {"GREEN", BASE_COLOR_GREEN},
+	 {"YELLOWGREEN", BASE_COLOR_YELLOW_GREEN},
+	 {"YELLOW", BASE_COLOR_YELLOW},
+	 {"YELLOWORANGE", BASE_COLOR_YELLOW_ORANGE},
+	 {"ORANGE", BASE_COLOR_ORANGE},
+	 {"REDORANGE", BASE_COLOR_RED_ORANGE},
+	 {nullptr, BASE_COLOR_NO}};
+
+Mode
+modeFromString(const std::string &mode_str)
+{
+	return Util::StringToGet(mode_map, mode_str);
+}
+
+BaseColor
+baseColorFromString(const std::string &base_str)
+{
+	return Util::StringToGet(base_color_map, base_str);
+}
+
+static void
+getSteps(Mode mode, std::vector<int> &steps)
+{
+	if (mode >= 0 && mode < PALETTE_NO) {
+		for (int i = 0; mode_steps[mode][i]; i++) {
+			steps.push_back(mode_steps[mode][i]);
+		}
+	}
+}
+
+/**
+ * Get colors as XColor for the given mode and base color. Caller is responsible
+ * for calling X11::returnColor on the returned colors.
+ */
+bool
+getColors(Mode mode, BaseColor base, uint intensity,
+	  std::vector<XColor*> colors)
+{
+	std::vector<std::string> str_colors;
+	if (! getColors(mode, base, intensity, str_colors)) {
+		return false;
+	}
+
+	std::vector<std::string>::iterator it(str_colors.begin());
+	for (; it != str_colors.end(); ++it) {
+		colors.push_back(X11::getColor(*it));
+	}
+	return true;
+}
+
+/**
+ * Get colors as strings in format #rrggbb for the given mode and base color.
+ */
+bool
+getColors(Mode mode, BaseColor base, uint intensity,
+	  std::vector<std::string> &colors)
+{
+	if (mode >= PALETTE_NO || base >= BASE_COLOR_NO
+	    || intensity >= COLORS_PER_BASE) {
+		return false;
+	}
+
+	std::vector<int> steps;
+	uint idx = static_cast<uint>(base) * COLORS_PER_BASE + intensity;
+	colors.push_back(COLORS[idx]);
+	getSteps(mode, steps);
+	std::vector<int>::iterator it(steps.begin());
+	for (; it != steps.end(); ++it) {
+		idx = (idx + *it * COLORS_PER_BASE) % COLORS_SIZE;
+		colors.push_back(COLORS[idx]);
+	}
+	return true;
+}
+
+};

--- a/src/tk/ColorPalette.hh
+++ b/src/tk/ColorPalette.hh
@@ -1,0 +1,56 @@
+//
+// ColorPalette.hh for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "config.h"
+#include "Compat.hh"
+#include "Types.hh"
+#include "X11.hh"
+
+#include <vector>
+#include <string>
+
+namespace ColorPalette {
+
+enum Mode {
+	PALETTE_SINGLE,
+	PALETTE_COMPLEMENTARY,
+	PALETTE_TRIAD,
+	PALETTE_ANALOGOUS,
+	PALETTE_SPLIT,
+	PALETTE_TETRAD,
+	PALETTE_SQUARE,
+	PALETTE_NO
+};
+
+enum BaseColor {
+	BASE_COLOR_RED,
+	BASE_COLOR_RED_PURPLE,
+	BASE_COLOR_PURPLE,
+	BASE_COLOR_BLUE_PURPLE,
+	BASE_COLOR_BLUE,
+	BASE_COLOR_BLUE_GREEN,
+	BASE_COLOR_GREEN,
+	BASE_COLOR_YELLOW_GREEN,
+	BASE_COLOR_YELLOW,
+	BASE_COLOR_YELLOW_ORANGE,
+	BASE_COLOR_ORANGE,
+	BASE_COLOR_RED_ORANGE,
+	BASE_COLOR_NO
+};
+
+const uint MAX_INTENSITY = 4;
+
+Mode modeFromString(const std::string &mode_str);
+BaseColor baseColorFromString(const std::string &base_str);
+
+bool getColors(Mode mode, BaseColor base, uint intensity,
+	       std::vector<XColor*> &colors);
+bool getColors(Mode mode, BaseColor base, uint intensity,
+	       std::vector<std::string> &colors);
+
+};

--- a/src/tk/ThemeUtil.cc
+++ b/src/tk/ThemeUtil.cc
@@ -1,0 +1,133 @@
+//
+// ThemeUtil.hh for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "Debug.hh"
+#include "ColorPalette.hh"
+#include "ThemeUtil.hh"
+
+#include <map>
+
+extern "C" {
+#include <assert.h>
+}
+
+namespace ThemeUtil {
+
+static void
+setCfgParserOptions(CfgParser &cfg, const std::string &dir, bool end_early)
+{
+	// FIXME: cfg.getOpt().setConfigScriptPath());
+	cfg.getOpt().setEndEarlyKey(end_early ? "REQUIRE" : "");
+	cfg.getOpt().setRegisterXResource(true);
+	cfg.setVar("THEME_DIR", dir);
+
+}
+
+static bool
+loadPalette(ColorPalette::Mode mode, ColorPalette::BaseColor base_color,
+	    uint intensity, const std::string &name,
+	    std::map<std::string, std::string> &vars)
+{
+	std::vector<std::string> colors;
+	if (! getColors(mode, base_color, intensity, colors)) {
+		return false;
+	}
+
+	std::vector<std::string>::iterator it(colors.begin());
+	for (int i = 0; it != colors.end(); ++it, i++) {
+		std::string key = name + std::to_string(i) + "_"
+			+ std::to_string(intensity);
+		vars[key] = *it;
+	}
+	return true;
+}
+
+static void
+loadPalette(CfgParser::Entry *section,
+	    std::map<std::string, std::string> &vars)
+{
+	if (! section) {
+		return;
+	}
+
+	std::string mode_str, base_str;
+
+	CfgParserKeys keys;
+	keys.add_string("MODE", mode_str);
+	keys.add_string("BASE", base_str);
+	section->parseKeyValues(keys.begin(), keys.end());
+
+	bool err = false;
+	ColorPalette::Mode mode = ColorPalette::modeFromString(mode_str);
+	ColorPalette::BaseColor base_color =
+		ColorPalette::baseColorFromString(base_str);
+	for (uint i = 0; i <= ColorPalette::MAX_INTENSITY; i++) {
+		if (! loadPalette(mode, base_color, i, section->getValue(),
+				  vars)) {
+			err = true;
+		}
+	}
+
+	if (err) {
+		USER_WARN("failed to get colors for Palette "
+			  << section->getValue() << ". Mode: " << mode_str
+			  << " Base: " << base_str);
+	}
+}
+
+bool
+load(CfgParser &cfg, const std::string &dir, const std::string &file,
+     bool overwrite)
+{
+	setCfgParserOptions(cfg, dir, true);
+	if (cfg.parse(file, CfgParserSource::SOURCE_FILE, overwrite)) {
+		loadRequire(cfg, dir, file);
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Load template quirks and palette.
+ */
+void
+loadRequire(CfgParser &cfg, const std::string &dir, const std::string &file)
+{
+	if (! cfg.isEndEarly()) {
+		return;
+	}
+
+	CfgParser::Entry *section = cfg.getEntryRoot()->findSection("REQUIRE");
+	assert(section); // was ended early, section must be present
+
+	// Check if Templates are enabled and setup palette colors
+	CfgParserKeys keys;
+	bool value_templates;
+	keys.add_bool("TEMPLATES", value_templates, false);
+	section->parseKeyValues(keys.begin(), keys.end());
+
+	std::map<std::string, std::string> vars;
+	CfgParser::Entry::entry_cit it = section->begin();
+	for (; it != section->end(); ++it) {
+		if (*(*it) == "PALETTE") {
+			loadPalette((*it)->getSection(), vars);
+		}
+	}
+
+	// Re-load configuration, potentially with templates enabled, and no
+	// early end on Require
+	cfg.clear(true);
+	setCfgParserOptions(cfg, dir, false);
+	std::map<std::string, std::string>::iterator var_it(vars.begin());
+	for (; var_it != vars.end(); ++var_it) {
+		cfg.setVar(var_it->first, var_it->second);
+	}
+	cfg.parse(file, CfgParserSource::SOURCE_FILE, value_templates);
+}
+
+};

--- a/src/tk/ThemeUtil.hh
+++ b/src/tk/ThemeUtil.hh
@@ -1,0 +1,23 @@
+//
+// ThemeUtil.hh for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#ifndef _THEME_UTIL_HH_
+#define _THEME_UTIL_HH_
+
+#include "CfgParser.hh"
+
+#include <string>
+
+namespace ThemeUtil {
+	bool load(CfgParser &cfg, const std::string &dir,
+		  const std::string &file, bool overwrite);
+	void loadRequire(CfgParser &cfg, const std::string &dir,
+			 const std::string &file);
+};
+
+#endif // _THEME_UTIL_HH_

--- a/test/test_ColorPalette.hh
+++ b/test/test_ColorPalette.hh
@@ -1,0 +1,95 @@
+//
+// test_ColorPalette.hh for pekwm
+// Copyright (C) 2025 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "test.hh"
+#include "tk/ColorPalette.hh"
+
+extern "C" {
+#include <string.h>
+}
+
+class TestColorPalette : public TestSuite {
+public:
+	TestColorPalette();
+	~TestColorPalette();
+
+	virtual bool run_test(TestSpec spec, bool status);
+
+private:
+	static void testGetColorsAsStrings();
+	static void testGetColorsInputValidation();
+};
+
+TestColorPalette::TestColorPalette(void)
+	: TestSuite("ColorPalette")
+{
+}
+
+TestColorPalette::~TestColorPalette(void)
+{
+}
+
+bool
+TestColorPalette::run_test(TestSpec spec, bool status)
+{
+	TEST_FN(spec, "getColorsAsStrings", testGetColorsAsStrings());
+	TEST_FN(spec, "getColorsInputValidation",
+		testGetColorsInputValidation());
+	return status;
+}
+
+void
+TestColorPalette::testGetColorsAsStrings()
+{
+	bool res;
+	std::vector<std::string> strs;
+	res = ColorPalette::getColors(ColorPalette::PALETTE_COMPLEMENTARY,
+			       ColorPalette::BASE_COLOR_RED, 0, strs);
+	ASSERT_TRUE("complementary", res);
+	ASSERT_EQUAL("complementary", 2, strs.size());
+	ASSERT_EQUAL("complementary", "#fbd3d0", strs[0]);
+	ASSERT_EQUAL("complementary", "#bfdfd0", strs[1]);
+
+	strs.clear();
+	res = ColorPalette::getColors(ColorPalette::PALETTE_TETRAD,
+			       ColorPalette::BASE_COLOR_ORANGE, 4, strs);
+	ASSERT_TRUE("tetrad wrap", res);
+	ASSERT_EQUAL("tetrad wrap", 4, strs.size());
+	ASSERT_EQUAL("tetrad wrap", "#9a4f06", strs[0]);
+	ASSERT_EQUAL("tetrad wrap", "#37075c", strs[1]);
+	ASSERT_EQUAL("tetrad wrap", "#013c73", strs[2]);
+	ASSERT_EQUAL("tetrad wrap", "#a29600", strs[3]);
+
+	strs.clear();
+	res = ColorPalette::getColors(ColorPalette::PALETTE_SINGLE,
+			       ColorPalette::BASE_COLOR_PURPLE, 0, strs);
+	ASSERT_TRUE("single", res);
+	ASSERT_EQUAL("single", 1, strs.size());
+	ASSERT_EQUAL("single", "#b8add5", strs[0]);
+}
+
+void
+TestColorPalette::testGetColorsInputValidation()
+{
+	bool res;
+	std::vector<std::string> strs;
+	res = ColorPalette::getColors(ColorPalette::PALETTE_NO,
+				      ColorPalette::BASE_COLOR_RED, 0, strs);
+	ASSERT_FALSE("invalid mode", res);
+	ASSERT_EQUAL("invalid mode", 0, strs.size());
+
+	res = ColorPalette::getColors(ColorPalette::PALETTE_TRIAD,
+				      ColorPalette::BASE_COLOR_NO, 0, strs);
+	ASSERT_FALSE("invalid base color", res);
+	ASSERT_EQUAL("invalid mode", 0, strs.size());
+
+	res = ColorPalette::getColors(ColorPalette::PALETTE_TRIAD,
+				      ColorPalette::BASE_COLOR_RED, 10, strs);
+	ASSERT_FALSE("invalid intensity", res);
+	ASSERT_EQUAL("invalid mode", 0, strs.size());
+}

--- a/test/test_pekwm.cc
+++ b/test/test_pekwm.cc
@@ -15,6 +15,7 @@
 #include "test_Action.hh"
 #include "test_AutoProperties.hh"
 #include "test_Config.hh"
+#include "test_ColorPalette.hh"
 #include "test_FontHandler.hh"
 #include "test_Frame.hh"
 #include "test_InputDialog.hh"
@@ -47,6 +48,8 @@ main_tests(int argc, char *argv[])
 
 	// Config
 	TestConfig testConfig;
+
+	TestColorPalette testColorPalette;
 
 	// Frame
 	TestFrame testFrame;


### PR DESCRIPTION
With the modes Complementary, Triad, Analogous, Split, Tetrad and Square and base colors Red, RedPurple, Purple, BluePurple, Blue, BlueGreen, Green, YellowGreen, Yellow, YellowOrange and RedOrange it is possible to define color variables in themes in the Require section.

As an example:

Require {
  Palette = "T" { Mode = "Triad"; Base = "Blue" }
}

will make the following variables available:

  * $T0_0, $T0_1, $T0_2, $T0_3, $T0_4 (color 1, intensity 0-4)
  * $T1_0, $T1_1, $T1_2, $T1_3, $T2_4 (color 2, intensity 0-4)
  * $T3_0, $T3_1, $T3_2, $T3_3, $T3_4 (color 3, intensity 0-4)